### PR TITLE
[feat/#1-security]: 로그인 및 회원 가입 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,12 +24,12 @@ repositories {
 }
 
 dependencies {
-	//implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-mustache'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
-	//runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.test_security:spring-security-test'

--- a/src/main/java/com/wondrous/test_security/config/SecurityConfig.java
+++ b/src/main/java/com/wondrous/test_security/config/SecurityConfig.java
@@ -22,7 +22,7 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable) //사이트 위변조 방지 설정 해제(개발 환경에서만)
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/", "/main", "/login", "h2-console").permitAll() // 로그인 없이 접근 가능하도록 설정
+                        .requestMatchers("/", "/main", "/login", "/loginProc", "/join", "/joinProc").permitAll() // 로그인 없이 접근 가능하도록 설정
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .requestMatchers("/user/**").hasAnyRole("USER", "ADMIN")
                         .anyRequest().authenticated()

--- a/src/main/java/com/wondrous/test_security/controller/JoinController.java
+++ b/src/main/java/com/wondrous/test_security/controller/JoinController.java
@@ -1,0 +1,20 @@
+package com.wondrous.test_security.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Controller
+public class JoinController {
+
+    @GetMapping("/join")
+    public String joinPage() {
+        return "/join";
+    }
+
+    @PostMapping("/joinProc")
+    public String joinProcess() {
+        //회원 가입 완료 시 로그인 페이지로 리디렉팅
+        return "redirect:/login";
+    }
+}

--- a/src/main/java/com/wondrous/test_security/controller/JoinController.java
+++ b/src/main/java/com/wondrous/test_security/controller/JoinController.java
@@ -1,11 +1,19 @@
 package com.wondrous.test_security.controller;
 
+import com.wondrous.test_security.dto.JoinRequestDto;
+import com.wondrous.test_security.service.JoinService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequiredArgsConstructor
 
 @Controller
 public class JoinController {
+
+    private final JoinService joinService;
 
     @GetMapping("/join")
     public String joinPage() {
@@ -13,7 +21,9 @@ public class JoinController {
     }
 
     @PostMapping("/joinProc")
-    public String joinProcess() {
+    public String joinProcess(JoinRequestDto request) {
+        System.out.println(request.getMemberName());
+        joinService.join(request);
         //회원 가입 완료 시 로그인 페이지로 리디렉팅
         return "redirect:/login";
     }

--- a/src/main/java/com/wondrous/test_security/controller/JoinController.java
+++ b/src/main/java/com/wondrous/test_security/controller/JoinController.java
@@ -3,12 +3,14 @@ package com.wondrous.test_security.controller;
 import com.wondrous.test_security.dto.JoinRequestDto;
 import com.wondrous.test_security.service.JoinService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @RequiredArgsConstructor
+@Slf4j
 
 @Controller
 public class JoinController {
@@ -22,7 +24,7 @@ public class JoinController {
 
     @PostMapping("/joinProc")
     public String joinProcess(JoinRequestDto request) {
-        System.out.println(request.getMemberName());
+        log.info(request.toString());
         joinService.join(request);
         //회원 가입 완료 시 로그인 페이지로 리디렉팅
         return "redirect:/login";

--- a/src/main/java/com/wondrous/test_security/dto/CustomUserDetails.java
+++ b/src/main/java/com/wondrous/test_security/dto/CustomUserDetails.java
@@ -1,0 +1,75 @@
+package com.wondrous.test_security.dto;
+
+
+import com.wondrous.test_security.enrity.Member;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class CustomUserDetails implements UserDetails {
+
+    private Member memberEntity;
+    //생성자 주입 방식으로 넣어 주기
+    public CustomUserDetails(Member entity) {
+    this.memberEntity = entity;
+}
+
+    //권한을 반환하는 메서드
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+
+        Collection<GrantedAuthority> collection = new ArrayList<GrantedAuthority>();
+
+        collection.add(new GrantedAuthority() {
+            @Override
+            public String getAuthority() {
+                return memberEntity.getRole();
+            }
+        });
+        return collection;
+    }
+
+    @Override
+    public String getPassword() {
+        return memberEntity.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return memberEntity.getMemberName();
+    }
+
+    /**
+     *사용자의 세션에 관한 정보를 가져오는 메서드들: 강제 세션 설정 후 수정 예정
+     */
+    @Override
+    public boolean isAccountNonExpired() {
+        //return UserDetails.super.isAccountNonExpired();
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        //return UserDetails.super.isAccountNonLocked();
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        //return UserDetails.super.isCredentialsNonExpired();
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        //return UserDetails.super.isEnabled();
+        return true;
+    }
+
+
+
+
+}

--- a/src/main/java/com/wondrous/test_security/dto/JoinRequestDto.java
+++ b/src/main/java/com/wondrous/test_security/dto/JoinRequestDto.java
@@ -1,0 +1,18 @@
+package com.wondrous.test_security.dto;
+
+import com.wondrous.test_security.enrity.Member;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class JoinRequestDto {
+    private String memberName;
+    private String passWord;
+
+    public Member toEntity() {
+        return Member.builder()
+                .userName(memberName)
+                .build();
+    }
+}

--- a/src/main/java/com/wondrous/test_security/dto/JoinRequestDto.java
+++ b/src/main/java/com/wondrous/test_security/dto/JoinRequestDto.java
@@ -1,14 +1,17 @@
 package com.wondrous.test_security.dto;
 
 import com.wondrous.test_security.enrity.Member;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+
 public class JoinRequestDto {
     private String memberName;
-    private String passWord;
+    private String password;
 
     public Member toEntity() {
         return Member.builder()

--- a/src/main/java/com/wondrous/test_security/dto/JoinRequestDto.java
+++ b/src/main/java/com/wondrous/test_security/dto/JoinRequestDto.java
@@ -12,7 +12,7 @@ public class JoinRequestDto {
 
     public Member toEntity() {
         return Member.builder()
-                .userName(memberName)
+                .memberName(memberName)
                 .build();
     }
 }

--- a/src/main/java/com/wondrous/test_security/enrity/Member.java
+++ b/src/main/java/com/wondrous/test_security/enrity/Member.java
@@ -18,7 +18,7 @@ public class Member {
     private Long id;
 
     @Column(unique = true, nullable = false)
-    private String userName;
+    private String memberName;
 
     private String password;
 

--- a/src/main/java/com/wondrous/test_security/enrity/Member.java
+++ b/src/main/java/com/wondrous/test_security/enrity/Member.java
@@ -1,0 +1,28 @@
+package com.wondrous.test_security.enrity;
+
+import com.wondrous.test_security.dto.JoinRequestDto;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+
+@Table(name = "member")
+@Entity
+public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String userName;
+
+    private String password;
+
+    private String role;
+
+
+}

--- a/src/main/java/com/wondrous/test_security/enrity/Member.java
+++ b/src/main/java/com/wondrous/test_security/enrity/Member.java
@@ -8,6 +8,7 @@ import lombok.*;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 @Builder
 
 @Table(name = "member")
@@ -17,7 +18,7 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true, nullable = false)
+    @Column(unique = true)
     private String memberName;
 
     private String password;

--- a/src/main/java/com/wondrous/test_security/repository/MemberRepository.java
+++ b/src/main/java/com/wondrous/test_security/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.wondrous.test_security.repository;
+
+import com.wondrous.test_security.enrity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/src/main/java/com/wondrous/test_security/repository/MemberRepository.java
+++ b/src/main/java/com/wondrous/test_security/repository/MemberRepository.java
@@ -4,5 +4,5 @@ import com.wondrous.test_security.enrity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-
+    boolean existsByMemberName(String userName);
 }

--- a/src/main/java/com/wondrous/test_security/repository/MemberRepository.java
+++ b/src/main/java/com/wondrous/test_security/repository/MemberRepository.java
@@ -4,5 +4,7 @@ import com.wondrous.test_security.enrity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Member findByMemberName(String memberName);
     boolean existsByMemberName(String userName);
 }

--- a/src/main/java/com/wondrous/test_security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/wondrous/test_security/service/CustomUserDetailsService.java
@@ -1,0 +1,31 @@
+package com.wondrous.test_security.service;
+
+import com.wondrous.test_security.dto.CustomUserDetails;
+import com.wondrous.test_security.enrity.Member;
+import com.wondrous.test_security.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Slf4j
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        Member member = memberRepository.findByMemberName(username);
+        log.info(member.toString());
+        if (member == null) {
+            throw new UsernameNotFoundException(username);
+        }
+        return new CustomUserDetails(member);
+    }
+}

--- a/src/main/java/com/wondrous/test_security/service/JoinService.java
+++ b/src/main/java/com/wondrous/test_security/service/JoinService.java
@@ -18,7 +18,10 @@ public class JoinService {
     public void join(JoinRequestDto request) {
 
         //DB에 이미 동일한 회원이 있는지 확인
-
+        boolean existMember = memberRepository.existsByMemberName(request.getMemberName());
+        if (existMember) {
+            throw new IllegalArgumentException("이미 존재하는 회원 입니다.");
+        }
 
         //User 데이터 입력
         Member member = request.toEntity();
@@ -30,5 +33,6 @@ public class JoinService {
 
         //유저 정보 저장
         memberRepository.save(member);
+        //이후 문자열 정규식 활용하여 유효성 설정
     }
 }

--- a/src/main/java/com/wondrous/test_security/service/JoinService.java
+++ b/src/main/java/com/wondrous/test_security/service/JoinService.java
@@ -27,7 +27,7 @@ public class JoinService {
 
         //User 데이터 입력
         Member member = request.toEntity();
-        member.setRole("ROLE_USER");
+        member.setRole("ROLE_ADMIN");
 
         //비밀 번호 암호화
         member.setPassword(bCryptPasswordEncoder.encode(request.getPassword()));

--- a/src/main/java/com/wondrous/test_security/service/JoinService.java
+++ b/src/main/java/com/wondrous/test_security/service/JoinService.java
@@ -4,10 +4,12 @@ import com.wondrous.test_security.dto.JoinRequestDto;
 import com.wondrous.test_security.enrity.Member;
 import com.wondrous.test_security.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
+@Slf4j
 
 @Service
 public class JoinService {
@@ -28,8 +30,9 @@ public class JoinService {
         member.setRole("ROLE_USER");
 
         //비밀 번호 암호화
-        member.setPassword(bCryptPasswordEncoder.encode(member.getPassword()));
+        member.setPassword(bCryptPasswordEncoder.encode(request.getPassword()));
 
+        log.info("JoinService.join - memberName: {}, password: {}", member.getMemberName(), member.getPassword());
 
         //유저 정보 저장
         memberRepository.save(member);

--- a/src/main/java/com/wondrous/test_security/service/JoinService.java
+++ b/src/main/java/com/wondrous/test_security/service/JoinService.java
@@ -1,0 +1,34 @@
+package com.wondrous.test_security.service;
+
+import com.wondrous.test_security.dto.JoinRequestDto;
+import com.wondrous.test_security.enrity.Member;
+import com.wondrous.test_security.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+
+@Service
+public class JoinService {
+
+    private final MemberRepository memberRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    public void join(JoinRequestDto request) {
+
+        //DB에 이미 동일한 회원이 있는지 확인
+
+
+        //User 데이터 입력
+        Member member = request.toEntity();
+        member.setRole("ROLE_USER");
+
+        //비밀 번호 암호화
+        member.setPassword(bCryptPasswordEncoder.encode(member.getPassword()));
+
+
+        //유저 정보 저장
+        memberRepository.save(member);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,0 @@
-spring.application.name=security
-logging.level.org.springframework.security=DEBUG
-logging.level.org.springframework.web=INFO

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,8 @@ spring:
 
 
 
+
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/member?useSSL=false&useUnicode=true&character_set_server=utf8mb4&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,24 @@
+spring:
+  application:
+    name: security
+  servlet:
+    encoding:
+      force-response: true
+
+  jpa:
+    properties:
+        hibernate:
+          dialect: org.hibernate.dialect.MySQL8Dialect
+    hibernate:
+      ddl-auto: create
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/member?useSSL=false&useUnicode=true&character_set_server=utf8mb4&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+    username: root
+    password: "0000"
+
+
+logging:
+  level:
+    root: info

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,24 +1,41 @@
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+      force-response: 'true'
+
+
 spring:
   application:
     name: security
-  servlet:
-    encoding:
-      force-response: true
+
+
 
   jpa:
     properties:
         hibernate:
           dialect: org.hibernate.dialect.MySQL8Dialect
+          format_sql: true
+          highlight_sql: true
+          use_sql_comments: true
+
+    show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+
+
+
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/member?useSSL=false&useUnicode=true&character_set_server=utf8mb4&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+    url: jdbc:mysql://localhost:3306/member?useSSL=false&useUnicode=true&character_set_server=utf8mb4&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true
     username: root
     password: "0000"
-
 
 logging:
   level:
     root: info
+    org.hibernate.sql: debug
+    org.hibernate.type.descriptor.sql: debug

--- a/src/main/resources/templates/join.mustache
+++ b/src/main/resources/templates/join.mustache
@@ -9,7 +9,7 @@
 <body>
     <form action="/joinProc" method="post" name="joinForm">
         <label>
-            <input type="text" name="username" placeholder="Username"/>
+            <input type="text" name="memberName" placeholder="Username"/>
         </label>
         <label>
             <input type="password" name="password" placeholder="Password"/>

--- a/src/main/resources/templates/join.mustache
+++ b/src/main/resources/templates/join.mustache
@@ -1,0 +1,20 @@
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Join Page</title>
+</head>
+<body>
+    <form action="/joinProc" method="post" name="joinForm">
+        <label>
+            <input type="text" name="username" placeholder="Username"/>
+        </label>
+        <label>
+            <input type="password" name="password" placeholder="Password"/>
+        </label>
+        <input type="submit" value="Join" />
+    </form>
+</body>
+</html>


### PR DESCRIPTION
 # ✒️ 관련 이슈번호
- https://github.com/kimgt0128/security-hands-on-Spring-boot-3/issues/1
  
  


# 🔑 Key Changes
- MySQL 의존성 추가
- 권한별 경로 설정
  - authorizeHttpRequests
- 로그인 기능 구현
  - BCryptPasswordEncoder로 패스워드 암호화
- 회원 가입 기능 구현
  - 회원 가입시 "ROLE_USER" 부여
- 회원 가입 중복 검증 구현
  - existByMemberName메서드 생성 
- 로그인 중복 검증 구현 
  - CustomUserDetails 구현
    - getAuthorities
    - GetPassword
    - GetUsername
    - 이후 부분은 강제 true를 반환(이후 세션 설정에서 구현 예정)
  - CustomUserDetailsService 구현



# 📢 After To-do
- [ ] 세션 정보 설정 예정
- [ ] 계층 권한 설정 에정