### PR TITLE
[feat/#1-security]: 유저 세션 정보 설정

### DIFF
--- a/src/main/java/com/wondrous/test_security/config/SecurityConfig.java
+++ b/src/main/java/com/wondrous/test_security/config/SecurityConfig.java
@@ -20,7 +20,12 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(AbstractHttpConfigurer::disable) //사이트 위변조 방지 설정 해제(개발 환경에서만)
+                /**
+                 * 사이트 위변조 방지 설정 해제
+                 * 개발 환경 or JWT 구현 방식에서만 해제
+                 * 아무 설정도 없으면 enable이 기본 설정
+                 * .csrf(AbstractHttpConfigurer::disable)
+                 */
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/", "/login", "/loginProc", "/join", "/joinProc").permitAll() // 로그인 없이 접근 가능하도록 설정
                         .requestMatchers("/main", "/user/**").hasAnyRole("ADMIN", "MANAGER", "USER")
@@ -41,7 +46,10 @@ public class SecurityConfig {
                 //세션 고정 보호 설정
                 .sessionManagement((auth) -> auth
                         .sessionFixation().changeSessionId()
-                );
+                )
+                //로그아웃 엔드포인트 설정
+                .logout((auth) -> auth.logoutUrl("/logout")
+                        .logoutSuccessUrl("/"));
         return http.build();
     }
 }

--- a/src/main/java/com/wondrous/test_security/config/SecurityConfig.java
+++ b/src/main/java/com/wondrous/test_security/config/SecurityConfig.java
@@ -31,6 +31,15 @@ public class SecurityConfig {
                         .loginPage("/login")
                         .loginProcessingUrl("/loginProc")
                         .permitAll()
+                )
+                .sessionManagement((auth) -> auth
+                        .maximumSessions(3)
+                        .maxSessionsPreventsLogin(true)
+
+                )
+                //세션 고정 보호 설정
+                .sessionManagement((auth) -> auth
+                        .sessionFixation().changeSessionId()
                 );
         return http.build();
     }

--- a/src/main/java/com/wondrous/test_security/config/SecurityConfig.java
+++ b/src/main/java/com/wondrous/test_security/config/SecurityConfig.java
@@ -2,6 +2,8 @@ package com.wondrous.test_security.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -22,6 +24,14 @@ public class SecurityConfig {
     }
 
     @Bean
+    public RoleHierarchy roleHierarchy() {
+        RoleHierarchyImpl roleHierarchy = new RoleHierarchyImpl();
+        roleHierarchy.setHierarchy("ROLE_ADMIN > ROLE_MANAGER\n" +
+                "ROLE_MANAGER > ROLE_USER");
+        return roleHierarchy;
+    }
+
+    @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 /**
@@ -32,8 +42,8 @@ public class SecurityConfig {
                  */
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/", "/login", "/loginProc", "/join", "/joinProc").permitAll() // 로그인 없이 접근 가능하도록 설정
-                        .requestMatchers("/main", "/user/**").hasAnyRole("ADMIN", "MANAGER", "USER")
-                        .requestMatchers("/manager/**").hasAnyRole("ADMIN", "MANAGER")
+                        .requestMatchers("/main", "/user/**").hasAnyRole("USER")
+                        .requestMatchers("/manager/**").hasAnyRole("MANAGER")
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/wondrous/test_security/config/SecurityConfig.java
+++ b/src/main/java/com/wondrous/test_security/config/SecurityConfig.java
@@ -22,9 +22,10 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable) //사이트 위변조 방지 설정 해제(개발 환경에서만)
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/", "/main", "/login", "/loginProc", "/join", "/joinProc").permitAll() // 로그인 없이 접근 가능하도록 설정
+                        .requestMatchers("/", "/login", "/loginProc", "/join", "/joinProc").permitAll() // 로그인 없이 접근 가능하도록 설정
+                        .requestMatchers("/main", "/user/**").hasAnyRole("ADMIN", "MANAGER", "USER")
+                        .requestMatchers("/manager/**").hasAnyRole("ADMIN", "MANAGER")
                         .requestMatchers("/admin/**").hasRole("ADMIN")
-                        .requestMatchers("/user/**").hasAnyRole("USER", "ADMIN")
                         .anyRequest().authenticated()
                 )
                 .formLogin((auth) -> auth

--- a/src/main/java/com/wondrous/test_security/config/SecurityConfig.java
+++ b/src/main/java/com/wondrous/test_security/config/SecurityConfig.java
@@ -5,7 +5,11 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -52,4 +56,28 @@ public class SecurityConfig {
                         .logoutSuccessUrl("/"));
         return http.build();
     }
+
+//    @Bean
+//    public UserDetailsService users() {
+//        BCryptPasswordEncoder passwordEncoder = bCryptPasswordEncoder();
+//        User.UserBuilder users = User.builder();
+//
+//        UserDetails adminUser = users
+//                .username("admin")
+//                        .password(passwordEncoder.encode("1234"))
+//                        .roles("ADMIN").build();
+//
+//        UserDetails managerUser = users
+//                .username("manager")
+//                .password(passwordEncoder.encode("1234"))
+//                .roles("MANAGER").build();
+//
+//        UserDetails userUser = users
+//                .username("user")
+//                .password(passwordEncoder.encode("1234"))
+//                .roles("USER").build();
+//
+//        return new InMemoryUserDetailsManager(adminUser, managerUser, userUser);
+//
+//    }
 }

--- a/src/main/java/com/wondrous/test_security/config/SecurityConfig.java
+++ b/src/main/java/com/wondrous/test_security/config/SecurityConfig.java
@@ -25,10 +25,27 @@ public class SecurityConfig {
 
     @Bean
     public RoleHierarchy roleHierarchy() {
-        RoleHierarchyImpl roleHierarchy = new RoleHierarchyImpl();
-        roleHierarchy.setHierarchy("ROLE_ADMIN > ROLE_MANAGER\n" +
-                "ROLE_MANAGER > ROLE_USER");
-        return roleHierarchy;
+
+        /*****6.3.x 버전 이전 RoleHierarchy 설정**********************
+         ----------------------------------------------------------
+         RoleHierarchyImpl roleHierarchy = new RoleHierarchyImpl();
+         roleHierarchy.setHierarchy("ROLE_ADMIN > ROLE_MANAGER\n" +
+                 "ROLE_MANAGER > ROLE_USER");
+         return roleHierarchy;
+         ----------------------------------------------------------
+         6.3.x 이후 버전(ROLE_접두사 수동)
+         ----------------------------------------------------------
+         return RoleHierarchyImpl.fromHierarchy("""
+                 ROLE_ADMIN > ROLE_MANAGER
+                 ROLE_MANAGER > ROME_USER
+                 """);
+         -----------------------------------------------------------
+         */
+        // ROLE 접두사 자동생성
+        return RoleHierarchyImpl.withDefaultRolePrefix()
+                .role("ADMIN").implies("MANAGER")
+                .role("MANAGER").implies("USER")
+                .build();
     }
 
     @Bean

--- a/src/main/java/com/wondrous/test_security/controller/LogoutController.java
+++ b/src/main/java/com/wondrous/test_security/controller/LogoutController.java
@@ -1,0 +1,35 @@
+package com.wondrous.test_security.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.Collections;
+
+@Slf4j
+
+@Controller
+public class LogoutController {
+
+    @GetMapping("/logout")
+    public String logout(HttpServletRequest request, HttpServletResponse response) {
+        log.info("Session Attributes: {}", Collections.list(request.getSession().getAttributeNames()));
+        log.info("Session ID: {}", request.getSession().getId());
+        log.info("Request URI: {}", request.getRequestURI());
+        log.info("Request Method: {}", request.getMethod());
+        log.info("Request IP: {}", request.getRemoteAddr());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null) {
+             log.info("Logging out user: {}", authentication.getName());
+             new SecurityContextLogoutHandler().logout(request, response, authentication);
+        }
+        log.info(String.valueOf(response.getStatus()));
+        return "redirect:/login";
+    }
+}

--- a/src/main/java/com/wondrous/test_security/controller/MainController.java
+++ b/src/main/java/com/wondrous/test_security/controller/MainController.java
@@ -1,13 +1,34 @@
 package com.wondrous.test_security.controller;
 
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.Collection;
+import java.util.Iterator;
 
 @Controller
 public class MainController {
 
     @GetMapping("/main")
-    public String index() {
+    public String index(Model model) {
+        /**
+         * 현재 로그인한 사용자의 정보를 가져오는 메서드
+         * 원래 서비스 계층에서 유저의 정보를 가져와야 하지만 편의상 컨트롤러에서 진행
+         */
+        String id = SecurityContextHolder.getContext().getAuthentication().getName();
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> Iterator = authorities.iterator();
+        GrantedAuthority grantedAuthority = Iterator.next();
+        String role = grantedAuthority.getAuthority();
+
+        model.addAttribute("id",id);
+        model.addAttribute("role", role);
         return "/main";
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,8 @@ server:
     encoding:
       charset: UTF-8
       force-response: 'true'
+    session:
+      timeout: 10m
 
 
 spring:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,9 @@ spring:
   application:
     name: security
 
-
+  mustache:
+    servlet:
+      expose-request-attributes: true
 
   jpa:
     properties:

--- a/src/main/resources/templates/join.mustache
+++ b/src/main/resources/templates/join.mustache
@@ -15,6 +15,7 @@
             <input type="password" name="password" placeholder="Password"/>
         </label>
         <input type="submit" value="Join" />
+        <input type="hidden" name="_csrf" value = "{{_csrf.token}}">
     </form>
 </body>
 </html>

--- a/src/main/resources/templates/login.mustache
+++ b/src/main/resources/templates/login.mustache
@@ -12,6 +12,7 @@
     <form action="/loginProc" method="post" name="loginForm">
         <label for="username"></label><input id="username" type="text" name="username" placeholder="id"/>
         <label for="password"></label><input id="password" type="password" name="password" placeholder="password"/>
+        <input type="hidden" name="_csrf" value = "{{_csrf.token}}">
         <input type="submit" value="login"/>
     </form>
     </body>

--- a/src/main/resources/templates/main.mustache
+++ b/src/main/resources/templates/main.mustache
@@ -7,6 +7,9 @@
     <title>메인 페이지</title>
 </head>
 <body>
-    <p>Main Page</p>
+    <h1>Main Page</h1>
+    <hr>
+    id: {{id}} <br>
+    role: {{role}}
 </body>
 </html>


### PR DESCRIPTION
 # ✒️ 관련 이슈번호
- https://github.com/kimgt0128/security-hands-on-Spring-boot-3/issues/1
   

# 🔑 Key Changes
- main페이지에서 유저 id, ROLE 불러오기
- 사용자 세션 정보 설정
  - 지속 시간 설정
  - 세션 보호 설정
- csrf 설정
  - mustache에서 요청 허용 & token 추가
  -  시큐리티에서 로그아웃 요청을 SecurityContexteHolder을 통한 자체 처리
- "MANAGER" 권한 추가
- 인메모리 유저 주석만 추가
- 로그아웃 컨트롤러 구현
- 계층 권한 설정
  - 6.3.4버전을 적용한 최신 코드로 수정


# 📢 After To-do
- [ ] ADMIN, MANAGER 페이지 생성 & 컨트롤러 구현
- [ ] 회원가입, 로그인 작동 테스트
- [ ] mustache 페이지 스타일 적용시키기(머티리얼UI 이용)